### PR TITLE
Use ordereddict on Python2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ Now you can run
 sudo python lersyslog import FILE_PATH
 ```
 
+Running le_rsyslog on Python2.6
+---
+On Python2.6, `le_rsyslog` requires `ordereddict`:
+
+```
+sudo pip install ordereddict
+```

--- a/lersyslog
+++ b/lersyslog
@@ -20,7 +20,10 @@ import urllib
 
 # ------------------- Constants section --------------------
 # Application version
-import collections
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 LE_LERSYSLOG_NAME = 'lersyslog'
 # This value should be replaced by version generator
@@ -1330,7 +1333,7 @@ class RSyslogHelper:
             def __init__(self, format, type):
                 self.format = format
                 self.type = type
-                self.items = collections.OrderedDict()
+                self.items = OrderedDict()
                 self.other_items_count = 0
                 self.polling_items_count = 0
                 self.routing_rules_general = 0


### PR DESCRIPTION
With this change, `le_rsyslog` seems to work fine on Python2.6.